### PR TITLE
Fix Helm warings

### DIFF
--- a/charts/vllm/templates/deployment.yaml
+++ b/charts/vllm/templates/deployment.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: vllm-{{ .Values.model.name | lower }}
+    name: vllm-{{ .Values.model.name | lower | replace "." "" }}
     namespace: {{ .Release.Namespace }}
     labels:
-      {{- include "vllm.selectorLabels" . | nindent 4 }}
+      {{- include "vllm.selectorLabels" . | nindent 6 }}
 spec:
     replicas: 1
     selector:
       matchLabels:
-        app: vllm-{{ .Values.model.name | lower }}
+        app: vllm-{{ .Values.model.name | lower  | replace "." "" }}
     template:
       metadata:
         labels:
-          app: vllm-{{ .Values.model.name | lower }}
+          app: vllm-{{ .Values.model.name | lower | replace "." "" }}
       spec:
         volumes:
         - name: cache-volume

--- a/charts/vllm/templates/pvc.yaml
+++ b/charts/vllm/templates/pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vllm-{{ .Values.model.name | lower }}
   labels:
     {{- include "vllm.labels" . | nindent 4 }}
-namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/vllm/templates/service.yaml
+++ b/charts/vllm/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.service.name | lower }}
-namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: http-{{ .Values.service.name | lower }}
@@ -10,6 +10,6 @@ spec:
     protocol: TCP
     targetPort: 8000
   selector:
-    app: vllm-{{ .Values.model.name | lower }}
+    app: vllm-{{ .Values.model.name | lower | replace "." "" }}
   sessionAffinity: None
   type: ClusterIP


### PR DESCRIPTION
Haven't fully tested, but this commit will fix the following warning messages:

```
W1114 22:00:59.986973   19415 warnings.go:70] unknown field "namespace"
W1114 22:00:59.991982   19415 warnings.go:70] unknown field "namespace"
W1114 22:00:59.997351   19415 warnings.go:70] unknown field "metadata.app.kubernetes.io/component"
W1114 22:00:59.997358   19415 warnings.go:70] unknown field "metadata.app.kubernetes.io/instance"
W1114 22:00:59.997360   19415 warnings.go:70] metadata.name: this is used in Pod names and hostnames, which can result in surprising behavior; a DNS label is recommended: [must not contain dots]
```